### PR TITLE
Update Dockerfile with NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommend
     wget \
     openjdk-8-jdk \
     openjdk-11-jdk \
-    openjdk-17-jdk
+    openjdk-17-jdk \
+    npm
 
 # Install donet SDK
 RUN curl https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh


### PR DESCRIPTION
Add NPM to be installed as default
This is to avoid error `##[error]No agent found in pool unraid-pool which satisfies the specified demands: npm, Agent.Version -gtVersion 2.160.0` in case nodejs apps are built on that agent